### PR TITLE
get_user_context corrected

### DIFF
--- a/app/core/dependencies.py
+++ b/app/core/dependencies.py
@@ -4,15 +4,17 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.repositories.user_repository import UserRepository
 from app.services.user_service import UserService
 from app.services.auth_service import AuthService
+from contextlib import asynccontextmanager
 
 async def get_db() -> AsyncGenerator[AsyncSession, None]:
     async with session_manager.session() as session:
         yield session
 
+@asynccontextmanager
 async def get_user_context():
-    async for session in get_db():
+    async with session_manager.session() as session:
         user_repo = UserRepository(session)
-        return {
+        yield {
             "user_service": UserService(user_repo),
             "auth_service": AuthService(user_repo)
         }

--- a/scripts/setup_database.py
+++ b/scripts/setup_database.py
@@ -1,0 +1,37 @@
+from app.config.database import engine
+from app.db.base import Base
+import asyncio
+from sqlalchemy import inspect
+from app.models.user import User
+from app.models.base import BasicModel
+
+async def create_tables():
+    print("[INFO] Starting table creation...")
+
+    try:
+        async with engine.begin() as conn:
+            print("[INFO] Connected to the database.")
+            print("[DEBUG] Current tables in metadata:", Base.metadata.tables.keys())
+            await conn.run_sync(Base.metadata.create_all)
+            print("[SUCCESS] Tables created via metadata.\n")
+
+            def inspect_db(connection):
+                inspector = inspect(connection)
+                tables = inspector.get_table_names()
+                print("[INFO] Tables present in database:")
+                for table_name in tables:
+                    print(f"  📄 {table_name}")
+                    columns = inspector.get_columns(table_name)
+                    for col in columns:
+                        print(f"     - {col['name']} ({col['type']})")
+
+            await conn.run_sync(inspect_db)
+
+        await engine.dispose()
+        print("\n[INFO] Engine disposed. Setup complete.")
+
+    except Exception as e:
+        print(f"[ERROR] Failed to create or inspect tables: {e}")
+
+if __name__ == "__main__":
+    asyncio.run(create_tables())

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,17 +1,31 @@
 import asyncio
 from sqlalchemy import text
 from app.db.session import session_manager
+from app.core.dependencies import get_user_context, get_db
+from sqlalchemy.inspection import inspect
+
+def model_to_dict(obj):
+    return {c.key: getattr(obj, c.key) for c in inspect(obj).mapper.column_attrs}
 
 async def test_db():
     try:
-        async with session_manager.session() as session:
-            result = await session.execute(text("SELECT 1"))
-            print("✅ Database connected!")
-            print(f"Result: {result.fetchone()[0]}")
+        # async with session_manager.session() as session:
+        #     result = await session.execute(text("SELECT 1"))
+        #     print("✅ Database connected!")
+        #     print(f"Result: {result.fetchone()[0]}")
+            
+        # async for session in get_db():
+        #     result = await session.execute(text("SELECT 1"))
+        #     print("✅ Database connected!")
+        #     print(f"Result: {result.fetchone()[0]}")
+        
+        async with get_user_context() as user_repo:
+            users = await user_repo.get_all()
+            for user in users:
+                print(model_to_dict(user))
+
     except Exception as e:
         print(f"❌ Connection failed: {e}")
-    finally:
-        await session_manager.close()
 
 if __name__ == "__main__":
     asyncio.run(test_db())


### PR DESCRIPTION
Usage:

```
@router.get("/users/{user_id}")
async def get_user(user_id: int, ctx: UserContext = Depends(get_user_context)):
    user_service = ctx["user_service"]
    user = await user_service.get_user_by_id(user_id)
    return user
```

OR

```
async def some_async_function():
    async with get_user_context() as context:
        user_service = context["user_service"]
        user = await user_service.get_user_by_id(1)
        return user
```
